### PR TITLE
Bug/fix empty local namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -332,3 +332,6 @@ ASALocalRun/
 .localhistory/
 Console.ScoringEngine/appsettings.local.json
 nuget.config
+
+# NCrunch extension
+*.ncrunchsolution

--- a/Scoring.Tests/ResponseProcessingTests/GeneralTests.cs
+++ b/Scoring.Tests/ResponseProcessingTests/GeneralTests.cs
@@ -1,24 +1,19 @@
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Xml;
 using System.Xml.Linq;
-using Moq;
-using Citolab.QTI.ScoringEngine.Interfaces;
-using Citolab.QTI.ScoringEngine.Const;
+using Citolab.QTI.ScoringEngine.Helpers;
 using Citolab.QTI.ScoringEngine.Model;
-using Xunit;
 using Citolab.QTI.ScoringEngine.ResponseProcessing;
 using Microsoft.Extensions.Logging;
-using Citolab.QTI.ScoringEngine.Helpers;
-using System;
-using Castle.Core.Logging;
+using Moq;
+using Xunit;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace Citolab.QTI.ScoringEngine.Tests.Business
 {
     public class GeneralTests
     {
-
         /// <summary>
         /// Verify that the SCORE node is updated
         /// </summary>
@@ -30,12 +25,12 @@ namespace Citolab.QTI.ScoringEngine.Tests.Business
             var assessmentResult = new AssessmentResult(logger, XDocument.Load(File.OpenRead("Resources/2x/ResponseProcessing/AssessmentResult_Update_OutcomeVariable.xml")));
             var assessmentItem = new AssessmentItem(logger, XDocument.Load(File.OpenRead("Resources/2x/ResponseProcessing/ITM-50066.xml")), TestHelper.GetExpressionFactory());
 
-
             ResponseProcessor.Process(assessmentItem, assessmentResult, logger);
 
             var scoreValue = assessmentResult.GetScoreForItem("ITM-50066", "SCORE");
             Assert.Equal("1", scoreValue);
         }
+
         /// <summary>
         /// BUG: https://github.com/Citolab/qti-scoring-engine/issues/1
         /// </summary>
@@ -46,7 +41,6 @@ namespace Citolab.QTI.ScoringEngine.Tests.Business
 
             var assessmentResult = new AssessmentResult(logger, XDocument.Load(File.OpenRead("Resources/2x/ResponseProcessing/AssessmentResult_Update_OutcomeVariable.xml")));
             var assessmentItem = new AssessmentItem(logger, XDocument.Load(File.OpenRead("Resources/2x/ResponseProcessing/ITM-50066.xml")), TestHelper.GetExpressionFactory());
-
 
             ResponseProcessor.Process(assessmentItem, assessmentResult, logger);
             var itemResult = assessmentResult.FindElementsByElementAndAttributeValue("itemResult", "identifier", "ITM-50066").FirstOrDefault();
@@ -66,7 +60,6 @@ namespace Citolab.QTI.ScoringEngine.Tests.Business
             // make response incorrect
             assessmentResult.ChangeResponse("ITM-50066", "RESPONSE", "A");
 
-
             ResponseProcessor.Process(assessmentItem, assessmentResult, logger);
 
             var scoreValue = assessmentResult.GetScoreForItem("ITM-50066", "SCORE");
@@ -84,7 +77,6 @@ namespace Citolab.QTI.ScoringEngine.Tests.Business
             var assessmentResult = new AssessmentResult(logger, XDocument.Load(File.OpenRead("Resources/2x/ResponseProcessing/AssessmentResult_Add_OutcomeVariable.xml")));
             var assessmentItem = new AssessmentItem(logger, XDocument.Load(File.OpenRead("Resources/2x/ResponseProcessing/ITM-50066.xml")), TestHelper.GetExpressionFactory());
 
-
             ResponseProcessor.Process(assessmentItem, assessmentResult, logger);
 
             var scoreValue = assessmentResult.GetScoreForItem("ITM-50066", "SCORE");
@@ -96,7 +88,6 @@ namespace Citolab.QTI.ScoringEngine.Tests.Business
         /// Verify that the score will be zero when the given response doesn't match the correct answer
         /// </summary>
 
-
         /// <summary>
         /// MH: this used to throw an exception, but now response processing is applied it succeeds
         /// </summary>
@@ -107,7 +98,6 @@ namespace Citolab.QTI.ScoringEngine.Tests.Business
 
             var assessmentResult = new AssessmentResult(logger, XDocument.Load(File.OpenRead("Resources/2x/ResponseProcessing/AssessmentResult_Add_OutcomeVariable.xml")));
             var assessmentItem = new AssessmentItem(logger, XDocument.Load(File.OpenRead("Resources/2x/ResponseProcessing/ITM-50066_No_Correct_Response.xml")), TestHelper.GetExpressionFactory());
-
 
             ResponseProcessor.Process(assessmentItem, assessmentResult, logger);
 
@@ -127,7 +117,6 @@ namespace Citolab.QTI.ScoringEngine.Tests.Business
             Assert.Equal("2", scoreValue);
         }
 
-
         /// <summary>
         /// Verify that the score is equal to zero and everything work without a candidateResponse node
         /// </summary>
@@ -139,16 +128,11 @@ namespace Citolab.QTI.ScoringEngine.Tests.Business
             var assessmentResult = new AssessmentResult(logger, XDocument.Load(File.OpenRead("Resources/2x/ResponseProcessing/AssessmentResult_No_Candidate_Response.xml")));
             var assessmentItem = new AssessmentItem(logger, XDocument.Load(File.OpenRead("Resources/2x/ResponseProcessing/ITM-50069.xml")), TestHelper.GetExpressionFactory());
 
-
             ResponseProcessor.Process(assessmentItem, assessmentResult, logger);
 
             var scoreValue = assessmentResult.GetScoreForItem("ITM-50069", "SCORE");
             Assert.Equal("0", scoreValue);
         }
-
-
-
-
 
         /// <summary>
         /// Verify that an exception is thrown when an item has interpolation but no identifier/variable can be found in the LookupOutcomeValue element
@@ -162,12 +146,10 @@ namespace Citolab.QTI.ScoringEngine.Tests.Business
             var assessmentResult = new AssessmentResult(mockLogger.Object, XDocument.Load(File.OpenRead("Resources/2x/ResponseProcessing/AssessmentResult_Interpolation.xml")));
             var assessmentItem = new AssessmentItem(mockLogger.Object, XDocument.Load(File.OpenRead("Resources/2x/ResponseProcessing/083-Verklanking-Speciale-Tekens_No_Identifier_For_Variable_In_LookupOutcomeValue.xml")), TestHelper.GetExpressionFactory());
 
-
             ResponseProcessor.Process(assessmentItem, assessmentResult, mockLogger.Object);
             //No outcome identifier could be found for the raw score to use with interpolation.
             mockLogger.VerifyLog((state, t) => state.ContainsValue("No outcome identifier could be found for the raw score to use with interpolation."), LogLevel.Error, 1);
         }
-
 
         [Fact]
         public void ResponseProcessing_30_ExternalMachine()
@@ -176,7 +158,6 @@ namespace Citolab.QTI.ScoringEngine.Tests.Business
 
             var assessmentResult = new AssessmentResult(mockLogger.Object, XDocument.Load(File.OpenRead("Resources/30/ResponseProcessing/IMS-examples/assessment_result_external_machine.xml")));
             var assessmentItem = new AssessmentItem(mockLogger.Object, XDocument.Load(File.OpenRead("Resources/30/ResponseProcessing/IMS-examples/text-entry-qti3.xml")), TestHelper.GetExpressionFactory());
-
 
             ResponseProcessor.Process(assessmentItem, assessmentResult, mockLogger.Object);
 
@@ -192,12 +173,55 @@ namespace Citolab.QTI.ScoringEngine.Tests.Business
             var assessmentResult = new AssessmentResult(mockLogger.Object, XDocument.Load(File.OpenRead("Resources/30/ResponseProcessing/IMS-examples/assessment_result_human.xml")));
             var assessmentItem = new AssessmentItem(mockLogger.Object, XDocument.Load(File.OpenRead("Resources/30/ResponseProcessing/IMS-examples/text-entry-qti3.xml")), TestHelper.GetExpressionFactory());
 
-
             ResponseProcessor.Process(assessmentItem, assessmentResult, mockLogger.Object);
 
             var scoreValue = assessmentResult.GetScoreForItem("textEntry", "SCORE");
             // variable should be untouched when human scored
             Assert.Equal("1", scoreValue);
+        }
+
+        [Fact]
+        public void ResponseProcessing_30_Should_Keep_Local_Namespace()
+        {
+            var logger = new Mock<ILogger>().Object;
+
+            var assessmentResult = new AssessmentResult(logger, XDocument.Load(File.OpenRead("Resources/30/ResponseProcessing/IMS-examples/assessment_result_external_machine.xml")));
+            var assessmentItem = new AssessmentItem(logger, XDocument.Load(File.OpenRead("Resources/30/ResponseProcessing/IMS-examples/text-entry-qti3.xml")), TestHelper.GetExpressionFactory());
+
+            var result = ResponseProcessor.Process(assessmentItem, assessmentResult, logger);
+
+            Assert.NotNull(result);
+
+            // Empty xmlns check can only be done using a raw xml read on an XmlDocument (XDocument filters them out)
+            var rawXml = result.ToString();
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(rawXml);
+            string xpathQuery = "//*[namespace-uri() = '' and local-name() != '']";
+
+            // No empty xmlns should be found
+            XmlNodeList nodesWithEmptyXmlns = xmlDoc.SelectNodes(xpathQuery);
+            Assert.Empty(nodesWithEmptyXmlns);
+        }
+
+        [Fact]
+        public void ResponseProcessing_2x_Should_Keep_Local_Namespace()
+        {
+            var logger = new Mock<ILogger>().Object;
+
+            var assessmentResult = new AssessmentResult(logger, XDocument.Load(File.OpenRead("Resources/2x/ResponseProcessing/AssessmentResult_Update_OutcomeVariable.xml")));
+            var assessmentItem = new AssessmentItem(logger, XDocument.Load(File.OpenRead("Resources/2x/ResponseProcessing/ITM-50066.xml")), TestHelper.GetExpressionFactory());
+
+            var result = ResponseProcessor.Process(assessmentItem, assessmentResult, logger);
+
+            // Empty xmlns check can only be done using a raw xml read on an XmlDocument (XDocument filters them out)
+            var rawXml = result.ToString();
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(rawXml);
+            string xpathQuery = "//*[namespace-uri() = '' and local-name() != '']";
+
+            // No empty xmlns should be found
+            XmlNodeList nodesWithEmptyXmlns = xmlDoc.SelectNodes(xpathQuery);
+            Assert.Empty(nodesWithEmptyXmlns);
         }
     }
 }

--- a/Scoring.Tests/ResponseProcessingTests/GeneralTests.cs
+++ b/Scoring.Tests/ResponseProcessingTests/GeneralTests.cs
@@ -180,38 +180,19 @@ namespace Citolab.QTI.ScoringEngine.Tests.Business
             Assert.Equal("1", scoreValue);
         }
 
-        [Fact]
-        public void ResponseProcessing_30_Should_Keep_Local_Namespace()
+        [Theory]
+        [InlineData("Resources/30/ResponseProcessing/IMS-examples/assessment_result_external_machine.xml", "Resources/30/ResponseProcessing/IMS-examples/text-entry-qti3.xml")]
+        [InlineData("Resources/2x/ResponseProcessing/AssessmentResult_Update_OutcomeVariable.xml", "Resources/2x/ResponseProcessing/ITM-50066.xml")]
+        public void ResponseProcessing_Should_Keep_Local_Namespace(string assessmentResultFile, string assessmentItemFile)
         {
             var logger = new Mock<ILogger>().Object;
 
-            var assessmentResult = new AssessmentResult(logger, XDocument.Load(File.OpenRead("Resources/30/ResponseProcessing/IMS-examples/assessment_result_external_machine.xml")));
-            var assessmentItem = new AssessmentItem(logger, XDocument.Load(File.OpenRead("Resources/30/ResponseProcessing/IMS-examples/text-entry-qti3.xml")), TestHelper.GetExpressionFactory());
+            var assessmentResult = new AssessmentResult(logger, XDocument.Load(File.OpenRead(assessmentResultFile)));
+            var assessmentItem = new AssessmentItem(logger, XDocument.Load(File.OpenRead(assessmentItemFile)), TestHelper.GetExpressionFactory());
 
             var result = ResponseProcessor.Process(assessmentItem, assessmentResult, logger);
 
             Assert.NotNull(result);
-
-            // Empty xmlns check can only be done using a raw xml read on an XmlDocument (XDocument filters them out)
-            var rawXml = result.ToString();
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(rawXml);
-            string xpathQuery = "//*[namespace-uri() = '' and local-name() != '']";
-
-            // No empty xmlns should be found
-            XmlNodeList nodesWithEmptyXmlns = xmlDoc.SelectNodes(xpathQuery);
-            Assert.Empty(nodesWithEmptyXmlns);
-        }
-
-        [Fact]
-        public void ResponseProcessing_2x_Should_Keep_Local_Namespace()
-        {
-            var logger = new Mock<ILogger>().Object;
-
-            var assessmentResult = new AssessmentResult(logger, XDocument.Load(File.OpenRead("Resources/2x/ResponseProcessing/AssessmentResult_Update_OutcomeVariable.xml")));
-            var assessmentItem = new AssessmentItem(logger, XDocument.Load(File.OpenRead("Resources/2x/ResponseProcessing/ITM-50066.xml")), TestHelper.GetExpressionFactory());
-
-            var result = ResponseProcessor.Process(assessmentItem, assessmentResult, logger);
 
             // Empty xmlns check can only be done using a raw xml read on an XmlDocument (XDocument filters them out)
             var rawXml = result.ToString();

--- a/Scoring.Tests/ScoringEngine.Tests.v3.ncrunchproject
+++ b/Scoring.Tests/ScoringEngine.Tests.v3.ncrunchproject
@@ -1,0 +1,7 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <HiddenComponentWarnings>
+      <Value>LongTestTimesWithoutParallelExecution</Value>
+    </HiddenComponentWarnings>
+  </Settings>
+</ProjectConfiguration>

--- a/Scoring/Model/AssessmentResult.cs
+++ b/Scoring/Model/AssessmentResult.cs
@@ -1,14 +1,10 @@
-﻿using Microsoft.Extensions.Logging;
-using Citolab.QTI.ScoringEngine.Const;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
 using Citolab.QTI.ScoringEngine.Helpers;
 using Citolab.QTI.ScoringEngine.Interfaces;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Xml.Linq;
 using Citolab.QTI.ScoringEngine.ResponseProcessing;
+using Microsoft.Extensions.Logging;
 
 namespace Citolab.QTI.ScoringEngine.Model
 {
@@ -20,6 +16,7 @@ namespace Citolab.QTI.ScoringEngine.Model
         public string SourcedId { get; set; }
 
         private readonly ILogger _logger;
+
         public AssessmentResult(ILogger logger, XDocument assessmentResult) : base(assessmentResult)
         {
             _logger = logger;
@@ -37,6 +34,7 @@ namespace Citolab.QTI.ScoringEngine.Model
                   return GetResult<ItemResult>(itemResultElement);
               }).ToDictionary(itemResult => itemResult.Identifier, itemResult => itemResult);
         }
+
         public void InitTestResults()
         {
             TestResults = Root
@@ -101,14 +99,15 @@ namespace Citolab.QTI.ScoringEngine.Model
                 {
                     outcomeVariable = outcome.ToElement().AddDefaultNamespace(Root.GetDefaultNamespace());
                     itemResultElement.Add(outcomeVariable.AddDefaultNamespace(Root.GetDefaultNamespace()));
-                } else if (outcomeVariable.GetAttributeValue("external-scored") == "human") {
+                }
+                else if (outcomeVariable.GetAttributeValue("external-scored") == "human")
+                {
                     // leave human scored outcomes alone
                     // do nothing
                 }
-                 else
+                else
                 {
-                    outcomeVariable.ReplaceWith(outcome.ToElement());
-                  
+                    outcomeVariable.ReplaceWith(outcome.ToElement().AddDefaultNamespace(Root.GetDefaultNamespace()));
                 }
                 //if (outcome.Value != null)
                 //{
@@ -132,7 +131,7 @@ namespace Citolab.QTI.ScoringEngine.Model
 
                 if (outcomeVariable != null)
                 {
-                    outcomeVariable.ReplaceWith(outcome.ToElement().AddDefaultNamespace(Root.GetDefaultNamespace()));       
+                    outcomeVariable.ReplaceWith(outcome.ToElement().AddDefaultNamespace(Root.GetDefaultNamespace()));
                 }
                 else
                 {
@@ -159,7 +158,6 @@ namespace Citolab.QTI.ScoringEngine.Model
                                {
                                    return new OutcomeVariable
                                    {
-
                                        Identifier = outcomeVariable.Identifier(),
                                        BaseType = outcomeVariable.GetAttributeValue("baseType").ToBaseType(),
                                        Cardinality = outcomeVariable.GetAttributeValue("cardinality").ToCardinality(),

--- a/Scoring/ScoringEngine.csproj
+++ b/Scoring/ScoringEngine.csproj
@@ -5,7 +5,7 @@
 		<RootNamespace>Citolab.QTI.ScoringEngine</RootNamespace>
 		<ProjectGuid>{2A7091CD-6A49-4B7B-85BB-A140C8B5397C}</ProjectGuid>
 		<PackageId>Citolab.QTI.ScoringEngine</PackageId>
-		<Version>1.2.1</Version>
+		<Version>1.2.2</Version>
 		<Company>Cito</Company>
 		<Copyright>Stichting Cito Instituut voor Toetsontwikkeling, Arnhem (2023)</Copyright>
 		<Authors>Citolab</Authors>

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,6 @@
+## 1.2.2
+* fixed empty xmlns in assessmentResult
+* 
 ## 1.2.1
 * fixed parsing float fails on specific cultures
 


### PR DESCRIPTION
The result  from the ResponseProcessor.Process function contained empty local namespaces on the SCORE outcomevariable.

This makes conversion to QTI 3 or 2x C# models an issue for ScoringEngine consumers, because there will be no content match using a deserializer.

Fixed by using the 'AddDefaultNamespace(Root.GetDefaultNamespace())' in the way it is also done when no outcomevariable is found.

Added 2 tests in an XUnit theory for verification.